### PR TITLE
fix: corrected url of npmjs.com/package/package-name

### DIFF
--- a/src/commands/cmds/cmdOpenNpm.ts
+++ b/src/commands/cmds/cmdOpenNpm.ts
@@ -1,6 +1,10 @@
 import * as vscode from 'vscode';
 import { CMD_VSCODE_OPEN, URL_NPM } from '../../constants';
+import { PackageListItem } from '../../treeviews/PackageList';
 
-export const cmdOpenNpm = (packageName: string): void => {
-  vscode.commands.executeCommand(CMD_VSCODE_OPEN, vscode.Uri.parse(`${URL_NPM}${packageName}`));
+export const cmdOpenNpm = (packageData: PackageListItem): void => {
+  vscode.commands.executeCommand(
+    CMD_VSCODE_OPEN,
+    vscode.Uri.parse(`${URL_NPM}${packageData.label}`)
+  );
 };

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -7,7 +7,7 @@ import {
   CMD_SELECT_FOLDER,
 } from '../constants';
 import { cmdDisplayPackage, cmdOpenNpm, cmdSearchNpm, cmdSelectFolder } from '.';
-import { PackageList } from '../treeviews';
+import { PackageList, PackageListItem } from '../treeviews';
 
 export const registerCommands = (
   context: vscode.ExtensionContext,
@@ -22,7 +22,7 @@ export const registerCommands = (
   );
 
   context.subscriptions.push(
-    registerCommand(CMD_OPEN_NPM, (packageName: string): void => {
+    registerCommand(CMD_OPEN_NPM, (packageName: PackageListItem): void => {
       cmdOpenNpm(packageName);
     })
   );

--- a/src/test/suite/commands/cmds/cmdOpenNpm.test.ts
+++ b/src/test/suite/commands/cmds/cmdOpenNpm.test.ts
@@ -3,11 +3,12 @@ import * as vscode from 'vscode';
 import { CMD_VSCODE_OPEN, URL_NPM } from '../../../../constants';
 import { cmdOpenNpm } from '../../../../commands';
 import { packageName } from '../../../mocks';
+import { PackageListItem } from '../../../../treeviews';
 
 suite('cmdOpenNpm()', () => {
   test('Calls vscode.commands.executeCommand()', () => {
     const spy = sinon.stub(vscode.commands, 'executeCommand');
-    cmdOpenNpm(packageName);
+    cmdOpenNpm({ label: packageName } as PackageListItem);
 
     sinon.assert.callCount(spy, 1);
     sinon.assert.calledWith(spy, CMD_VSCODE_OPEN);
@@ -16,7 +17,7 @@ suite('cmdOpenNpm()', () => {
 
   test('Calls vscode.Uri.parse()', () => {
     const spy = sinon.stub(vscode.Uri, 'parse');
-    cmdOpenNpm(packageName);
+    cmdOpenNpm({ label: packageName } as PackageListItem);
 
     sinon.assert.callCount(spy, 1);
     sinon.assert.calledWith(spy, `${URL_NPM}${packageName}`);


### PR DESCRIPTION
First of all, thanks a lot for building this extension.

![out](https://user-images.githubusercontent.com/16076136/84811884-2770af00-b02b-11ea-9a22-40069f2fa156.gif)


There is a minor bug in the url.
Steps to reproduce:
- Open Vscode
- Open any JS project
- Open this extension, PACKAGE, dependencies
- Click on the right end icon of any package.

Expected: 
- It should open the package homepage at npmjs.com
Ex: https://npmjs.com/package/react

Current:
- Its opening invalid url
Ex: http://npmjs.com/package/%5Bobject%20Object%5D

Reason:
For the `cmdOpenNpm` function, you are passing the entire package (as object)
instead of package name.
Javascript is trying to convert the object to string, which results in "[object Object]" instead of "package name"
